### PR TITLE
Restore pump shotgun inventory icon in fullscreen HUD. Closes #449

### DIFF
--- a/actors/Weapons/Slot3/SHOTGUN.dec
+++ b/actors/Weapons/Slot3/SHOTGUN.dec
@@ -1667,5 +1667,5 @@ ACTOR ShotgunAmmo : Ammo
    Inventory.MaxAmount 9
    Ammo.BackpackAmount 0
    Ammo.BackpackMaxAmount 9
-   Inventory.Icon "SHTCA1"
+   Inventory.Icon "SHTCA0"
 }


### PR DESCRIPTION
Inventory icon now refers to an actual existing image file which brings the ammo count for the pump shotgun back. ¨

Closes #449