### PR TITLE
Bring back total shell count in inventory for fullscreen HUD

### DIFF
--- a/actors/Items/Ammo/ShellboxBig.dec
+++ b/actors/Items/Ammo/ShellboxBig.dec
@@ -97,6 +97,7 @@ ACTOR NewShell : Ammo Replaces Shell
 	+DONTGIB
 	Inventory.Amount 4
 	Inventory.MaxAmount 50
+	Inventory.Icon "SBOXA0"
 	Ammo.BackpackAmount 4
 	Ammo.BackpackMaxAmount 100
 	States


### PR DESCRIPTION
Ammo type NewShell did not have an associated icon for the fullscreen HUD, which made the player unaware of total shell count.